### PR TITLE
Clean-up `tox -epy35` errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,10 @@ var/
 .eggs/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
-#  Usually these files are written by a python script from a template 
+#  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec

--- a/valet/api/db/models/music/__init__.py
+++ b/valet/api/db/models/music/__init__.py
@@ -297,7 +297,7 @@ def flush():
     pass
 
 
-from groups import Group  # noqa
-from ostro import PlacementRequest, PlacementResult, Event  # noqa
-from placements import Placement  # noqa
-from plans import Plan  # noqa
+from valet.api.db.models.music.groups import Group
+from valet.api.db.models.music.ostro import PlacementRequest, PlacementResult, Event
+from valet.api.db.models.music.placements import Placement
+from valet.api.db.models.music.plans import Plan

--- a/valet/engine/optimizer/ostro/openstack_filters.py
+++ b/valet/engine/optimizer/ostro/openstack_filters.py
@@ -11,11 +11,10 @@
 # under the License.
 
 # Modified: Mar. 15, 2016
-
-import openstack_utils
 import six
 
 from valet.engine.optimizer.app_manager.app_topology_base import VM
+import valet.engine.optimizer.ostro.openstack_utils
 
 _SCOPE = 'aggregate_instance_extra_specs'
 


### PR DESCRIPTION
Py35 does allow for the loading of modules in the same folder without
specifying the patch.  Updated import to use absolute pathing to clean-up
initial module not found exceptions.

This patch set also remove `# noqa` in EOF import statements.  Those
should be addressed in future patch set that do PEP8 clean up.  